### PR TITLE
Change test project path

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Build
       run: dotnet build ActiLink/ActiLink.sln --no-restore
     - name: Test
-      run: dotnet test ActiLink/ActiLink/ActiLink.csproj --no-build --verbosity normal
+      run: dotnet test ActiLink/ActiLink.UnitTests/ActiLink.UnitTests.csproj --no-build --verbosity normal


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/dotnet.yml` file to ensure that the correct test project is being executed during the CI workflow.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L28-R28): Modified the `Test` step to run tests from `ActiLink.UnitTests/ActiLink.UnitTests.csproj` instead of `ActiLink/ActiLink/ActiLink.csproj`.