### PR TITLE
Feature/users+events endpoints authorization

### DIFF
--- a/ActiLink/ActiLink.IntegrationTests/ActiLink.IntegrationTests.csproj
+++ b/ActiLink/ActiLink.IntegrationTests/ActiLink.IntegrationTests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest" Version="3.6.4" />

--- a/ActiLink/ActiLink.IntegrationTests/AuthorizationTests.cs
+++ b/ActiLink/ActiLink.IntegrationTests/AuthorizationTests.cs
@@ -76,34 +76,44 @@ namespace ActiLink.IntegrationTests
         [TestMethod]
         public async Task GetUserById_WithoutToken_ReturnsUnauthorized()
         {
-            var id = Guid.NewGuid();
+            // Arrange
+            var id = "c1a66a01-4d77-400b-b798-7b536120c568";
+            // Act
             var response = await _client.GetAsync($"/users/{id}");
+            // Assert
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
         [TestMethod]
         public async Task GetUserById_WithInvalidToken_ReturnsUnauthorized()
         {
-            var id = Guid.NewGuid();
+            // Arrange
+            var id = "efa37205-32bf-47ca-8ca4-bb4533db7729";
             var request = new HttpRequestMessage(HttpMethod.Get, $"/users/{id}");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid.token.value");
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
         [TestMethod]
         public async Task GetUserById_WithValidToken_AcceptsToken()
         {
-            var id = Guid.NewGuid();
+            // Arrange
+            var id = "8f895393-8201-42df-8a7e-50c2254e33a1";
             var request = new HttpRequestMessage(HttpMethod.Get, $"/users/{id}");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.IsTrue(response.StatusCode != HttpStatusCode.Unauthorized, "Should be authorized");
         }
 
         [TestMethod]
         public async Task CreateEvent_WithoutToken_ReturnsUnauthorized()
         {
+            // Arrange
             var request = new HttpRequestMessage(HttpMethod.Post, "/events")
             {
                 Content = JsonContent.Create(new
@@ -118,13 +128,15 @@ namespace ActiLink.IntegrationTests
                     RelatedHobbyIds = new List<Guid>() 
                 })
             };
-
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
         }
         [TestMethod]
         public async Task CreateEvent_WithInvalidToken_ReturnsUnauthorized()
         {
+            // Arrange
             var request = new HttpRequestMessage(HttpMethod.Post, "/events");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid.token.value");
 
@@ -138,13 +150,15 @@ namespace ActiLink.IntegrationTests
                 MinUsers = 5,
                 MaxUsers = 20
             });
-
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
         }
         [TestMethod]
         public async Task CreateEvent_WithValidToken_AcceptsToken()
         {
+            // Arrange
             var request = new HttpRequestMessage(HttpMethod.Post, "/events");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
 
@@ -158,15 +172,16 @@ namespace ActiLink.IntegrationTests
                 MinUsers = 5,
                 MaxUsers = 20
             });
-
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.AreNotEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Should be authorized");
             Assert.IsTrue(response.StatusCode is HttpStatusCode.Created or HttpStatusCode.BadRequest);
         }
         [TestMethod]
         public async Task GetEventById_WithoutToken_ReturnsUnauthorized()
         {
-            var id = Guid.NewGuid();
+            var id = "e869b0dd-91e9-4fce-9e53-8a15afac9ec5";
             var request = new HttpRequestMessage(HttpMethod.Get, $"/events/{id}");
             var response = await _client.SendAsync(request);
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -174,47 +189,62 @@ namespace ActiLink.IntegrationTests
         [TestMethod]
         public async Task GetEventById_WithInvalidToken_ReturnsUnauthorized()
         {
-            var id = Guid.NewGuid();
+            // Arrange
+            var id = "82230b3a-bf3c-466e-8329-281a301f4d45";
             var request = new HttpRequestMessage(HttpMethod.Get, $"/events/{id}");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid.token.value");
 
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
         }
         [TestMethod]
         public async Task GetEventById_WithValidToken_AcceptsToken()
         {
-            var id = Guid.NewGuid(); 
+            // Arrange
+            var id = "164d6163-1608-4458-98a7-66116111c298"; 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/events/{id}");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
 
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.AreNotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
             Assert.IsTrue(response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == HttpStatusCode.OK);
         }
         [TestMethod]
         public async Task GetAllEvents_WithoutToken_ReturnsUnauthorized()
         {
+            // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, "/events");
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
         }
         [TestMethod]
         public async Task GetAllEvents_WithInvalidToken_ReturnsUnauthorized()
         {
+            // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, "/events");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid.token.value");
 
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
         }
         [TestMethod]
         public async Task GetAllEvents_WithValidToken_AcceptsToken()
         {
+            // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, "/events");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
 
+            // Act
             var response = await _client.SendAsync(request);
+            // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         }
     }

--- a/ActiLink/ActiLink.IntegrationTests/AuthorizationTests.cs
+++ b/ActiLink/ActiLink.IntegrationTests/AuthorizationTests.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ActiLink.DTOs;
+using System.Net.Http.Json;
+using System.Net.Http.Headers;
+using ActiLink.Model;
+using ActiLink.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+
+
+namespace ActiLink.IntegrationTests
+{
+    [TestClass]
+    public class AuthorizationTests
+    {
+        private HttpClient _client = null!;
+        private string _token = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var factory = new CustomWebApplicationFactory();
+            _client = factory.CreateClient();
+
+            using var scope = factory.TestServices.CreateScope();
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<Organizer>>();
+            var tokenProvider = scope.ServiceProvider.GetRequiredService<JwtTokenProvider>();
+
+            var user = new User("TestUser", "testuser@example.com");
+            var result = userManager.CreateAsync(user, "Test_password123!").Result;
+            Assert.IsTrue(result.Succeeded, "Nie udało się stworzyć użytkownika");
+
+            _token = tokenProvider.GenerateAccessToken(user);
+        }
+
+        [TestMethod]
+        public async Task GetUsers_WithoutToken_ReturnsUnauthorized()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "/users");
+            // Act
+            var response = await _client.SendAsync(request);
+            // Assert
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task GetUsers_WithInvalidToken_ReturnsUnauthorized()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "/users");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid.token.value");
+            // Act
+            var response = await _client.SendAsync(request);
+            // Assert
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+        [TestMethod]
+        public async Task GetUsers_WithValidToken_AcceptsToken()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "/users");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            // Act
+            var response = await _client.SendAsync(request);
+            // Assert
+            Assert.IsTrue(response.StatusCode != HttpStatusCode.Unauthorized, "Should be authorized.");
+        }
+        [TestMethod]
+        public async Task GetUserById_WithoutToken_ReturnsUnauthorized()
+        {
+            var id = Guid.NewGuid();
+            var response = await _client.GetAsync($"/users/{id}");
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task GetUserById_WithInvalidToken_ReturnsUnauthorized()
+        {
+            var id = Guid.NewGuid();
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/users/{id}");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid.token.value");
+            var response = await _client.SendAsync(request);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task GetUserById_WithValidToken_AcceptsToken()
+        {
+            var id = Guid.NewGuid();
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/users/{id}");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            var response = await _client.SendAsync(request);
+            Assert.IsTrue(response.StatusCode != HttpStatusCode.Unauthorized, "Should be authorized");
+        }
+
+        [TestMethod]
+        public async Task CreateEvent_WithoutToken_ReturnsUnauthorized()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, "/events")
+            {
+                Content = JsonContent.Create(new
+                {
+                    StartTime = DateTime.UtcNow.AddDays(1),
+                    EndTime = DateTime.UtcNow.AddDays(2),
+                    Latitude = 50.061,
+                    Longitude = 19.938,
+                    Price = 10.5m,
+                    MinUsers = 5,
+                    MaxUsers = 20,
+                    RelatedHobbyIds = new List<Guid>() 
+                })
+            };
+
+            var response = await _client.SendAsync(request);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+        [TestMethod]
+        public async Task CreateEvent_WithInvalidToken_ReturnsUnauthorized()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, "/events");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid.token.value");
+
+            request.Content = JsonContent.Create(new
+            {
+                StartTime = DateTime.UtcNow.AddDays(1),
+                EndTime = DateTime.UtcNow.AddDays(2),
+                Latitude = 50.061,
+                Longitude = 19.938,
+                Price = 10.5m,
+                MinUsers = 5,
+                MaxUsers = 20
+            });
+
+            var response = await _client.SendAsync(request);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+        [TestMethod]
+        public async Task CreateEvent_WithValidToken_AcceptsToken()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, "/events");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+
+            request.Content = JsonContent.Create(new
+            {
+                StartTime = DateTime.UtcNow.AddDays(1),
+                EndTime = DateTime.UtcNow.AddDays(2),
+                Latitude = 50.061,
+                Longitude = 19.938,
+                Price = 10.5m,
+                MinUsers = 5,
+                MaxUsers = 20
+            });
+
+            var response = await _client.SendAsync(request);
+            Assert.AreNotEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Should be authorized");
+            Assert.IsTrue(response.StatusCode is HttpStatusCode.Created or HttpStatusCode.BadRequest);
+        }
+        [TestMethod]
+        public async Task GetEventById_WithoutToken_ReturnsUnauthorized()
+        {
+            var id = Guid.NewGuid();
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/events/{id}");
+            var response = await _client.SendAsync(request);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+        [TestMethod]
+        public async Task GetEventById_WithInvalidToken_ReturnsUnauthorized()
+        {
+            var id = Guid.NewGuid();
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/events/{id}");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid.token.value");
+
+            var response = await _client.SendAsync(request);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+        [TestMethod]
+        public async Task GetEventById_WithValidToken_AcceptsToken()
+        {
+            var id = Guid.NewGuid(); 
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/events/{id}");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+
+            var response = await _client.SendAsync(request);
+            Assert.AreNotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.IsTrue(response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == HttpStatusCode.OK);
+        }
+        [TestMethod]
+        public async Task GetAllEvents_WithoutToken_ReturnsUnauthorized()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/events");
+            var response = await _client.SendAsync(request);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+        [TestMethod]
+        public async Task GetAllEvents_WithInvalidToken_ReturnsUnauthorized()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/events");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid.token.value");
+
+            var response = await _client.SendAsync(request);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+        [TestMethod]
+        public async Task GetAllEvents_WithValidToken_AcceptsToken()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/events");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+
+            var response = await _client.SendAsync(request);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+}

--- a/ActiLink/ActiLink.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/ActiLink/ActiLink.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace ActiLink.IntegrationTests
+{
+    internal class CustomWebApplicationFactory : WebApplicationFactory<Program>
+    {
+        public IServiceProvider TestServices { get; private set; } = null!;
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            Environment.SetEnvironmentVariable("JWT_SECRET_KEY", "super_secret_test_key_12345678910");
+            Environment.SetEnvironmentVariable("JWT_VALID_ISSUER", "TestIssuer");
+            Environment.SetEnvironmentVariable("JWT_VALID_AUDIENCE", "TestAudience");
+
+            builder.UseEnvironment("Testing");
+
+            builder.ConfigureServices(services =>
+            {
+
+                services.AddDbContext<ApiContext>(options =>
+                {
+                    options.UseInMemoryDatabase("AuthorizationTestDb_" + Guid.NewGuid());
+                });
+
+                var sp = services.BuildServiceProvider();
+                using var scope = sp.CreateScope();
+                var context = scope.ServiceProvider.GetRequiredService<ApiContext>();
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                TestServices = sp;
+            });
+        }
+    }
+}

--- a/ActiLink/ActiLink.UnitTests/UserTests/UserTests.cs
+++ b/ActiLink/ActiLink.UnitTests/UserTests/UserTests.cs
@@ -20,7 +20,7 @@ namespace ActiLink.UnitTests.UserTests
         private Mock<IMapper> _mockMapper = null!;
         private UsersController _controller = null!;
         private UserService _userService = null!;
-        private TokenGenerator _tokenGenerator = null!;
+        private JwtTokenProvider _tokenGenerator = null!;
 
         [TestInitialize]
         public void Setup()
@@ -38,7 +38,7 @@ namespace ActiLink.UnitTests.UserTests
             Environment.SetEnvironmentVariable("JWT_VALID_AUDIENCE", "TestAudience");
 
             // Inicjalizacja TokenGenerator z mockowaną konfiguracją
-            _tokenGenerator = new TokenGenerator();
+            _tokenGenerator = new JwtTokenProvider();
 
             // Tworzenie rzeczywistej instancji UserService z mockami
             _userService = new UserService(

--- a/ActiLink/ActiLink.UnitTests/UserTests/UserTests.cs
+++ b/ActiLink/ActiLink.UnitTests/UserTests/UserTests.cs
@@ -153,6 +153,10 @@ namespace ActiLink.UnitTests.UserTests
             _mockUserManager.Setup(x => x.UpdateAsync(user))
                 .ReturnsAsync(IdentityResult.Success);
 
+            // Mockowanie UserManager.GenerateAccessTokenAsync
+            _mockUnitOfWork.Setup(u => u.SaveChangesAsync())
+                .ReturnsAsync(1);
+
             // Act
             var result = await _userService.LoginAsync(email, password);
 

--- a/ActiLink/ActiLink/ApiContext.cs
+++ b/ActiLink/ActiLink/ApiContext.cs
@@ -12,6 +12,7 @@ namespace ActiLink
         //DbSet<Organizer> Organizers { get; set; }
         DbSet<Event> Events { get; set; }  // Added DbSet for Event
         DbSet<Hobby> Hobbies { get; set; }
+        DbSet<RefreshToken> RefreshTokens { get; set; } // Added DbSet for RefreshToken
 
         public ApiContext(DbContextOptions<ApiContext> options) : base(options) { }
 

--- a/ActiLink/ActiLink/Configuration/JwtSettings.cs
+++ b/ActiLink/ActiLink/Configuration/JwtSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace ActiLink.Configuration
+{
+    public class JwtSettings
+    {
+        public int AccessTokenExpiryMinutes { get; set; }
+        public int RefreshTokenExpiryDays { get; set; }
+    }
+}

--- a/ActiLink/ActiLink/Controllers/EventsController.cs
+++ b/ActiLink/ActiLink/Controllers/EventsController.cs
@@ -2,6 +2,7 @@
 using ActiLink.Model;
 using ActiLink.Services;
 using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ActiLink.Controllers
@@ -31,6 +32,7 @@ namespace ActiLink.Controllers
         /// Returns a CreatedAtAction result with the created event's details or an error response.
         /// </returns>
         [HttpPost]
+        [Authorize]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> CreateEventAsync([FromBody] NewEventDto newEventDto)
@@ -69,6 +71,7 @@ namespace ActiLink.Controllers
         /// with the <see cref="EventDto"/> object or an error response if the event was not found.
         /// </returns>
         [HttpGet("{id}")]
+        [Authorize]
         [ActionName(nameof(GetEventByIdAsync))]
         [ProducesResponseType(typeof(EventDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -93,6 +96,7 @@ namespace ActiLink.Controllers
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IEnumerable{EventDto}"/> of all events.
         /// </returns>
         [HttpGet]
+        [Authorize]
         public async Task<IEnumerable<EventDto>> GetAllEventsAsync()
         {
             _logger.LogInformation("Fetching all events");

--- a/ActiLink/ActiLink/Controllers/EventsController.cs
+++ b/ActiLink/ActiLink/Controllers/EventsController.cs
@@ -35,6 +35,7 @@ namespace ActiLink.Controllers
         [Authorize]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> CreateEventAsync([FromBody] NewEventDto newEventDto)
         {
             Event? newEvent = null;
@@ -74,6 +75,7 @@ namespace ActiLink.Controllers
         [Authorize]
         [ActionName(nameof(GetEventByIdAsync))]
         [ProducesResponseType(typeof(EventDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetEventByIdAsync(Guid id)
         {
@@ -97,6 +99,8 @@ namespace ActiLink.Controllers
         /// </returns>
         [HttpGet]
         [Authorize]
+        [ProducesResponseType(typeof(IEnumerable<EventDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IEnumerable<EventDto>> GetAllEventsAsync()
         {
             _logger.LogInformation("Fetching all events");

--- a/ActiLink/ActiLink/Controllers/UsersController.cs
+++ b/ActiLink/ActiLink/Controllers/UsersController.cs
@@ -135,6 +135,8 @@ namespace ActiLink.Controllers
         /// </returns>
         [HttpGet]
         [Authorize]
+        [ProducesResponseType(typeof(IEnumerable<UserDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IEnumerable<UserDto>> GetUsersAsync()
         {
             _logger.LogInformation("Fetching all users");
@@ -154,6 +156,7 @@ namespace ActiLink.Controllers
         [Authorize]
         [ActionName(nameof(GetUserByIdAsync))]
         [ProducesResponseType<UserDto>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetUserByIdAsync([FromRoute] string id)
         {

--- a/ActiLink/ActiLink/Controllers/UsersController.cs
+++ b/ActiLink/ActiLink/Controllers/UsersController.cs
@@ -117,6 +117,7 @@ namespace ActiLink.Controllers
                 }
 
                 (string accessToken, string refreshToken) = result.Data!;
+                _logger.LogInformation("Token refresh successful");
                 return Ok(new TokenResponseDto(accessToken, refreshToken));
             }
             catch (Exception ex)
@@ -150,6 +151,7 @@ namespace ActiLink.Controllers
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IActionResult"/> of the operation with the <see cref="UserDto"/> if the user exists.  
         /// </returns>
         [HttpGet("{id}")]
+        [Authorize]
         [ActionName(nameof(GetUserByIdAsync))]
         [ProducesResponseType<UserDto>(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/ActiLink/ActiLink/Controllers/UsersController.cs
+++ b/ActiLink/ActiLink/Controllers/UsersController.cs
@@ -2,6 +2,7 @@
 using ActiLink.Model;
 using ActiLink.Services;
 using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ActiLink.Controllers
@@ -100,7 +101,7 @@ namespace ActiLink.Controllers
         /// </summary>
         /// <param name="refreshDto">DTO containing refresh token</param>
         /// <returns>New access token and refresh token</returns>
-        [HttpPost("refresh")]
+        [HttpPost("token")]
         [ProducesResponseType(typeof(TokenResponseDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> RefreshTokenAsync([FromBody] RefreshTokenDto refreshDto)
@@ -132,6 +133,7 @@ namespace ActiLink.Controllers
         /// The <see cref="Task"/> that represents the asynchronous operation, containing an <see cref="IEnumerable{UserDto}"/> of all users.
         /// </returns>
         [HttpGet]
+        [Authorize]
         public async Task<IEnumerable<UserDto>> GetUsersAsync()
         {
             _logger.LogInformation("Fetching all users");

--- a/ActiLink/ActiLink/Extensions/RefreshTokenRepositoryExtensions.cs
+++ b/ActiLink/ActiLink/Extensions/RefreshTokenRepositoryExtensions.cs
@@ -1,0 +1,21 @@
+﻿using ActiLink.Model;
+using ActiLink.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace ActiLink.Extensions
+{
+    public static class RefreshTokenRepositoryExtensions
+    {
+        public static async Task<RefreshToken?> GetValidTokenWithOwnerAsync(
+            this IRepository<RefreshToken> repository,
+            string token)
+        {
+            return await repository
+                .Query()
+                .Include(rt => rt.TokenOwner)
+                .FirstOrDefaultAsync(rt =>
+                    rt.Token == token &&
+                    rt.ExpiryTimeUtc > DateTime.UtcNow);
+        }
+    }
+}

--- a/ActiLink/ActiLink/Migrations/20250409221519_AddRefreshTokenTable.Designer.cs
+++ b/ActiLink/ActiLink/Migrations/20250409221519_AddRefreshTokenTable.Designer.cs
@@ -4,6 +4,7 @@ using ActiLink;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ActiLink.Migrations
 {
     [DbContext(typeof(ApiContext))]
-    partial class ApiContextModelSnapshot : ModelSnapshot
+    [Migration("20250409221519_AddRefreshTokenTable")]
+    partial class AddRefreshTokenTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ActiLink/ActiLink/Migrations/20250409221519_AddRefreshTokenTable.cs
+++ b/ActiLink/ActiLink/Migrations/20250409221519_AddRefreshTokenTable.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ActiLink.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokenTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AspNetUsers_Events_EventId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AspNetUsers_EventId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "EventId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "RefreshToken",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "RefreshTokenExpiryTime",
+                table: "AspNetUsers");
+
+            migrationBuilder.CreateTable(
+                name: "EventUser",
+                columns: table => new
+                {
+                    SignUpListId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    SignedUpEventsId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EventUser", x => new { x.SignUpListId, x.SignedUpEventsId });
+                    table.ForeignKey(
+                        name: "FK_EventUser_AspNetUsers_SignUpListId",
+                        column: x => x.SignUpListId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_EventUser_Events_SignedUpEventsId",
+                        column: x => x.SignedUpEventsId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Token = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    TokenOwnerId = table.Column<string>(type: "nvarchar(450)", nullable: true),
+                    ExpiryTimeUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_AspNetUsers_TokenOwnerId",
+                        column: x => x.TokenOwnerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EventUser_SignedUpEventsId",
+                table: "EventUser",
+                column: "SignedUpEventsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_TokenOwnerId",
+                table: "RefreshTokens",
+                column: "TokenOwnerId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EventUser");
+
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "EventId",
+                table: "AspNetUsers",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RefreshToken",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RefreshTokenExpiryTime",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUsers_EventId",
+                table: "AspNetUsers",
+                column: "EventId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AspNetUsers_Events_EventId",
+                table: "AspNetUsers",
+                column: "EventId",
+                principalTable: "Events",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/ActiLink/ActiLink/Model/Organizer.cs
+++ b/ActiLink/ActiLink/Model/Organizer.cs
@@ -7,8 +7,6 @@ namespace ActiLink.Model
     /// </summary>
     public abstract class Organizer : IdentityUser
     {
-        public string? RefreshToken { get; set; }
-        public DateTime? RefreshTokenExpiryTime { get; set; }
         public ICollection<Event> Events { get; private set; } = [];
         protected Organizer(string username, string email) : base(username)
         {

--- a/ActiLink/ActiLink/Model/RefreshToken.cs
+++ b/ActiLink/ActiLink/Model/RefreshToken.cs
@@ -1,0 +1,14 @@
+﻿namespace ActiLink.Model
+{
+    /// <summary>
+    /// Represents a refresh token.
+    public class RefreshToken
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string Token { get; set; } = null!;
+
+        public Organizer TokenOwner { get; set; } = null!;
+
+        public DateTime ExpiryTimeUtc { get; set; }
+    }
+}

--- a/ActiLink/ActiLink/Model/User.cs
+++ b/ActiLink/ActiLink/Model/User.cs
@@ -7,6 +7,7 @@
     {
 
         public ICollection<Hobby> Hobbies { get; } = [];
+        public ICollection<Event> SignedUpEvents { get; private set; } = [];
 
         public User(string userName, string email) : base(userName, email) { }
     }

--- a/ActiLink/ActiLink/Model/User.cs
+++ b/ActiLink/ActiLink/Model/User.cs
@@ -7,7 +7,6 @@
     {
 
         public ICollection<Hobby> Hobbies { get; } = [];
-        public ICollection<Event> SignedUpEvents { get; private set; } = [];
 
         public User(string userName, string email) : base(userName, email) { }
     }

--- a/ActiLink/ActiLink/Program.cs
+++ b/ActiLink/ActiLink/Program.cs
@@ -25,10 +25,15 @@ var dbPassword = Environment.GetEnvironmentVariable("DB_SA_PASSWORD");
 // TODO: test if the connection string is correct
 var connectionString = $"Server={dbHost},1433;Database={dbName};User Id=sa;Password={dbPassword};TrustServerCertificate=True;";
 
+var env = builder.Environment;
 
-// Add ApiContext with SQL Server database
-builder.Services.AddDbContext<ApiContext>(options =>
-    options.UseSqlServer(connectionString));
+// Do not use sql server with tests
+if (!env.IsEnvironment("Testing"))
+{
+    // Add ApiContext with SQL Server database
+    builder.Services.AddDbContext<ApiContext>(options =>
+        options.UseSqlServer(connectionString));
+}
 
 
 // Add services to the container.
@@ -51,6 +56,7 @@ builder.Services.AddOpenApi();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
+// Add Swagger with authorization
 builder.Services.AddSwaggerGen(options =>
 {
     options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo

--- a/ActiLink/ActiLink/Program.cs
+++ b/ActiLink/ActiLink/Program.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using ActiLink;
+using ActiLink.Configuration;
 using ActiLink.Model;
 using ActiLink.Repositories;
 using ActiLink.Services;
@@ -35,6 +36,9 @@ builder.Services.AddDbContext<ApiContext>(options =>
 // Add AutoMapper
 builder.Services.AddAutoMapper(typeof(Program));
 
+// Add configuration
+builder.Services.Configure<JwtSettings>(builder.Configuration.GetSection("JwtSettings"));
+
 // Add services
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IEventService, EventService>();
@@ -62,7 +66,7 @@ builder.Services.AddSwaggerGen(options =>
         Scheme = "Bearer",
         BearerFormat = "JWT",
         In = Microsoft.OpenApi.Models.ParameterLocation.Header,
-        Description = "WprowadŸ **Bearer &lt;twój_token&gt;**. Przyk³ad: `Bearer eyJhbGciOi...`"
+        Description = "Input **Bearer &lt;your_token&gt;**. Example: `Bearer eyJhbGciOi...`"
     });
 
     options.AddSecurityRequirement(new Microsoft.OpenApi.Models.OpenApiSecurityRequirement
@@ -106,20 +110,6 @@ builder.Services.AddAuthentication(options =>
             ValidateLifetime = true,
             ValidateIssuerSigningKey = true,
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Environment.GetEnvironmentVariable("JWT_SECRET_KEY")!))
-        };
-
-        options.Events = new JwtBearerEvents
-        {
-            OnMessageReceived = context =>
-            {
-                var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
-                if (!string.IsNullOrEmpty(authHeader) && !authHeader.StartsWith("Bearer "))
-                {
-                    context.Token = authHeader; // ustaw token rêcznie
-                }
-
-                return Task.CompletedTask;
-            }
         };
     });
 builder.Services.AddAuthorization();

--- a/ActiLink/ActiLink/Repositories/IUnitOfWork.cs
+++ b/ActiLink/ActiLink/Repositories/IUnitOfWork.cs
@@ -12,6 +12,7 @@ namespace ActiLink.Repositories
         /// </summary>
         IRepository<User> UserRepository { get; }
         IRepository<Event> EventRepository { get; }
+        IRepository<RefreshToken> RefreshTokenRepository { get; }
 
         /// <summary>
         /// Saves the changes to the database

--- a/ActiLink/ActiLink/Repositories/UnitOfWork.cs
+++ b/ActiLink/ActiLink/Repositories/UnitOfWork.cs
@@ -7,6 +7,7 @@ namespace ActiLink.Repositories
         private readonly ApiContext _context;
         private IRepository<User>? _userRepository;
         private IRepository<Event>? _eventRepository;
+        private IRepository<RefreshToken>? _refreshTokenRepository;
 
         public UnitOfWork(ApiContext context)
         {
@@ -15,7 +16,7 @@ namespace ActiLink.Repositories
 
         public IRepository<User> UserRepository => _userRepository ??= new Repository<User>(_context);
         public IRepository<Event> EventRepository => _eventRepository ??= new Repository<Event>(_context);
-
+        public IRepository<RefreshToken> RefreshTokenRepository => _refreshTokenRepository ??= new Repository<RefreshToken>(_context);
 
         public async Task<int> SaveChangesAsync()
         {

--- a/ActiLink/ActiLink/Services/JwtTokenProvider.cs
+++ b/ActiLink/ActiLink/Services/JwtTokenProvider.cs
@@ -7,13 +7,13 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace ActiLink.Services
 {
-    public class TokenGenerator
+    public class JwtTokenProvider
     {
         private readonly string _jwtSecret;
         private readonly string _jwtIssuer;
         private readonly string _jwtAudience;
 
-        public TokenGenerator()
+        public JwtTokenProvider()
         {
             _jwtSecret = Environment.GetEnvironmentVariable("JWT_SECRET_KEY") ?? throw new ArgumentNullException("JWT_SECRET_KEY environment variable is not set.");
             _jwtIssuer = Environment.GetEnvironmentVariable("JWT_VALID_ISSUER") ?? throw new ArgumentNullException("JWT_VALID_ISSUER environment variable is not set.");
@@ -27,6 +27,7 @@ namespace ActiLink.Services
 
             var claims = new[]
             {
+                new Claim("token_type", "access"),
                 new Claim(ClaimTypes.NameIdentifier, user.Id ?? ""),
                 new Claim(ClaimTypes.Email, user.Email ?? ""),
                 new Claim(ClaimTypes.Name, user.UserName ?? "")
@@ -45,12 +46,28 @@ namespace ActiLink.Services
             return tokenHandler.WriteToken(token);
         }
 
-        public string GenerateRefreshToken()
+        public string GenerateRefreshToken(string userId)
         {
-            var randomBytes = new byte[64];
-            using var rng = RandomNumberGenerator.Create();
-            rng.GetBytes(randomBytes);
-            return Convert.ToBase64String(randomBytes);
+            var key = Encoding.ASCII.GetBytes(_jwtSecret);
+            var tokenHandler = new JwtSecurityTokenHandler();
+
+            var claims = new[]
+            {
+                new Claim("token_type", "refresh"),
+                new Claim(ClaimTypes.NameIdentifier, userId),
+            };
+
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(claims),
+                Issuer = _jwtIssuer,
+                Audience = _jwtAudience,
+                Expires = DateTime.UtcNow.AddDays(30), 
+                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+            };
+
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            return tokenHandler.WriteToken(token);
         }
     }
 }

--- a/ActiLink/ActiLink/Services/UserService.cs
+++ b/ActiLink/ActiLink/Services/UserService.cs
@@ -1,4 +1,5 @@
-﻿using ActiLink.Model;
+﻿using ActiLink.Configuration;
+using ActiLink.Model;
 using ActiLink.Repositories;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -12,11 +13,13 @@ namespace ActiLink.Services
         private static readonly string[] InvalidLoginError = ["Invalid email or password."];
         private static readonly string[] InvalidRefreshTokenError = ["Invalid refresh token."];
         private readonly JwtTokenProvider _tokenProvider;
-        public UserService(IUnitOfWork unitOfWork, UserManager<Organizer> userManager, JwtTokenProvider provider)
+        private readonly JwtSettings _jwtSettings;
+        public UserService(IUnitOfWork unitOfWork, UserManager<Organizer> userManager, JwtTokenProvider provider, JwtSettings jwtSettings)
         {
             _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
             _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
             _tokenProvider = provider ?? throw new ArgumentNullException(nameof(provider));
+            _jwtSettings = jwtSettings ?? throw new ArgumentNullException(nameof(jwtSettings));
         }
 
         /// <summary>
@@ -62,7 +65,7 @@ namespace ActiLink.Services
             var refreshToken = _tokenProvider.GenerateRefreshToken(user.Id);
 
             user.RefreshToken = refreshToken;
-            user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(30);
+            user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(_jwtSettings.RefreshTokenExpiryDays);
 
             await _userManager.UpdateAsync(user);
 
@@ -92,7 +95,7 @@ namespace ActiLink.Services
             var newRefreshToken = _tokenProvider.GenerateRefreshToken(user.Id!);
 
             user.RefreshToken = newRefreshToken;
-            user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(30);
+            user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(_jwtSettings.RefreshTokenExpiryDays);
 
             await _userManager.UpdateAsync(user);
 

--- a/ActiLink/ActiLink/appsettings.json
+++ b/ActiLink/ActiLink/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+
+  "JwtSettings": {
+    "AccessTokenExpiryMinutes": 60,
+    "RefreshTokenExpiryDays": 30
+  }
 }

--- a/ActiLink/set-jwt-key.sh
+++ b/ActiLink/set-jwt-key.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 
 ENV_FILE=".env"
 VAR_NAME="JWT_SECRET"

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Po uruchomieniu aplikacji API będzie dostępne pod następującymi adresami:
 
 Można tam pozyskać informacje o dostępnych endpointach.
 
-Aby przetestować w swaggerze endpointy wymagające autoryzacji należy pozyskać swój **access token** (np. logując się) a następnie kliknąć w **Authorize** i wprowadzić token do pola formularza.
+Aby przetestować w Swaggerze endpointy wymagające autoryzacji należy pozyskać swój **access token** (np. logując się) a następnie kliknąć w **Authorize** i wprowadzić token do pola formularza.
 
 ![image](https://github.com/user-attachments/assets/30cc69bb-511f-48c7-b8b7-0fb446cf35ac)
 
-Token w tym plu należy podać w formacie:
+Token w tym polu należy podać w formacie:
 ```bash
 Bearer <twój_token>
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ Po uruchomieniu aplikacji API będzie dostępne pod następującymi adresami:
 
 Można tam pozyskać informacje o dostępnych endpointach.
 
+Aby przetestować w swaggerze endpointy wymagające autoryzacji należy pozyskać swój **access token** (np. logując się) a następnie kliknąć w **Authorize** i wprowadzić token do pola formularza.
+
+![image](https://github.com/user-attachments/assets/30cc69bb-511f-48c7-b8b7-0fb446cf35ac)
+
+Token w tym plu należy podać w formacie:
+```bash
+Bearer <twój_token>
+```
+
+Analogicznie, przy wysyłaniu zapytań HTTP np. z Postmana lub cURL, należy dodać nagłówek `Authorization`, gdzie:
+- **typ uwierzytelnienia (scheme)** to `Bearer`
+- **wartość** to sam token
+
+Przykład
+```
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+
 ## 📦 Instalacja i uruchomienie  
 Aby uruchomić backend lokalnie, wykonaj następujące kroki:  
 


### PR DESCRIPTION
Zrobione rzeczy:
- dodana autoryzacja na endpointach z userami i eventami
- zmiana sposobu generowania refresh tokenów na standard JWT + zmiana nazwy endpointu /users/refresh na /users/token
- migracja: przeniesienie informacji o refresh tokenach do osobnej tabeli i usunięcie z tabeli Users błędnie dodanej kolumny EventId
- przeniesienie informacji o żywotności tokenów do configu 
- dodanie możliwości autoryzacji do swaggera
- zmiany w UnitOfWork, UserTests i w UsersService związane z nowym przechowywaniem refresh tokenów
- testy poprawności autoryzacji z wykorzystaniem http client
- opis użycia w readme
- usunięta literówka w skrypcie do generowania kluczy