### PR TITLE
Feature/hobby endpoints

### DIFF
--- a/ActiLink/ActiLink.UnitTests/HobbyTests/HobbiesControllerTests.cs
+++ b/ActiLink/ActiLink.UnitTests/HobbyTests/HobbiesControllerTests.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ActiLink.Hobbies;
+using ActiLink.Hobbies.DTOs;
+using ActiLink.Hobbies.Service;
+using AutoMapper;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace ActiLink.UnitTests.HobbyTests
+{
+    [TestClass]
+    public class HobbiesControllerTests
+    {
+        private Mock<IHobbyService> _mockHobbyService = null!;
+        private Mock<IMapper> _mockMapper = null!;
+        private HobbiesController _hobbiesController = null!;
+
+        private readonly Guid id = new("030B4A82-1B7C-11CF-9D53-00AA003C9CB6");
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Initialize the mock unit of work and the hobby service
+            _mockHobbyService = new Mock<IHobbyService>();
+            _mockMapper = new Mock<IMapper>();
+
+            // Initialize the BusinessClientController with mocked dependencies
+            _hobbiesController = new HobbiesController(Mock.Of<ILogger<HobbiesController>>(), _mockHobbyService.Object, _mockMapper.Object);
+        }
+
+        [TestMethod]
+        public async Task GetHobbiesAsync_ShouldReturnAllHobbies()
+        {
+            // Given
+            string name1 = "Hobby1";
+            string name2 = "Hobby2";
+            var hobbies = new List<Hobby>
+            {
+                new(name1),
+                new(name2)
+            };
+
+            Utils.SetupHobbyGuid(hobbies[0], id);
+            Utils.SetupHobbyGuid(hobbies[1], id);
+
+            var expectedHobbyDtos = new List<HobbyDto>()
+            {
+                new(id, name1),
+                new(id, name2)
+            };
+
+            _mockHobbyService.Setup(uow => uow.GetHobbiesAsync())
+                .ReturnsAsync(hobbies);
+
+            _mockMapper.Setup(m => m.Map<IEnumerable<HobbyDto>>(hobbies))
+                .Returns(expectedHobbyDtos);
+
+
+            // When
+            var result = await _hobbiesController.GetHobbiesAsync();
+
+            // Then
+            var okResult = result as OkObjectResult;
+            Assert.IsNotNull(okResult);
+            Assert.AreEqual(200, okResult.StatusCode);
+            var hobbyDtos = okResult.Value as IEnumerable<HobbyDto>;
+            Assert.IsNotNull(hobbyDtos);
+            Assert.AreEqual(expectedHobbyDtos.Count, hobbyDtos.Count());
+            Assert.AreEqual(expectedHobbyDtos.First(), hobbyDtos.First());
+            Assert.AreEqual(expectedHobbyDtos.Last(), hobbyDtos.Last());
+            _mockHobbyService.Verify(uow => uow.GetHobbiesAsync(), Times.Once);
+            _mockMapper.Verify(m => m.Map<IEnumerable<HobbyDto>>(hobbies), Times.Once);
+
+        }
+
+        [TestMethod]
+        public async Task GetHobbiesAsync_ShouldReturnEmptyList()
+        {
+            // Given
+            _mockHobbyService.Setup(uow => uow.GetHobbiesAsync())
+                .ReturnsAsync([]);
+
+            // When
+            var result = await _hobbiesController.GetHobbiesAsync();
+
+            // Then
+            var okResult = result as OkObjectResult;
+            Assert.IsNotNull(okResult);
+            Assert.AreEqual(200, okResult.StatusCode);
+            var hobbyDtos = okResult.Value as IEnumerable<HobbyDto>;
+            Assert.IsNotNull(hobbyDtos);
+            Assert.AreEqual(0, hobbyDtos.Count());
+        }
+
+        [TestMethod]
+        public async Task GetHobbyByIdAsync_ShouldReturnHobby()
+        {
+            // Given
+            string name = "Hobby1";
+            var hobby = new Hobby(name);
+            Utils.SetupHobbyGuid(hobby, id);
+            var expectedHobbyDto = new HobbyDto(id, name);
+
+            _mockHobbyService.Setup(uow => uow.GetHobbyByIdAsync(id))
+                .ReturnsAsync(hobby);
+
+            _mockMapper.Setup(m => m.Map<HobbyDto>(hobby))
+                .Returns(expectedHobbyDto);
+
+
+            // When
+            var result = await _hobbiesController.GetHobbyByIdAsync(id);
+
+
+            // Then
+            var okResult = result as OkObjectResult;
+            Assert.IsNotNull(okResult);
+            Assert.AreEqual(200, okResult.StatusCode);
+            var hobbyDto = okResult.Value as HobbyDto;
+            Assert.IsNotNull(hobbyDto);
+            Assert.AreEqual(expectedHobbyDto, hobbyDto);
+        }
+
+        [TestMethod]
+        public async Task GetHobbyByIdAsync_ShouldReturnNotFound()
+        {
+            // Given
+            _mockHobbyService.Setup(uow => uow.GetHobbyByIdAsync(id))
+                .ReturnsAsync((Hobby?)null);
+
+            // When
+            var result = await _hobbiesController.GetHobbyByIdAsync(id);
+
+            // Then
+            var notFoundResult = result as NotFoundResult;
+            Assert.IsNotNull(notFoundResult);
+            Assert.AreEqual(404, notFoundResult.StatusCode);
+        }
+    }
+}

--- a/ActiLink/ActiLink.UnitTests/HobbyTests/HobbyServiceTests.cs
+++ b/ActiLink/ActiLink.UnitTests/HobbyTests/HobbyServiceTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ActiLink.Hobbies;
+using ActiLink.Hobbies.DTOs;
+using ActiLink.Hobbies.Service;
+using ActiLink.Shared.Repositories;
+using Moq;
+
+namespace ActiLink.UnitTests.HobbyTests
+{
+    [TestClass]
+    public class HobbyServiceTests
+    {
+        private Mock<IUnitOfWork> _mockUnitOfWork = null!;
+        private HobbyService _hobbyService = null!;
+        private readonly Guid id = new("030B4A82-1B7C-11CF-9D53-00AA003C9CB6");
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Initialize the mock unit of work and the hobby service
+            _mockUnitOfWork = new Mock<IUnitOfWork>();
+
+            // Initialize the BusinessClientService with mocked dependencies
+            _hobbyService = new HobbyService(_mockUnitOfWork.Object);
+        }
+
+        [TestMethod]
+        public async Task GetHobbiesAsync_ShouldReturnAllHobbies()
+        {
+            // Given
+            string name1 = "Hobby1";
+            string name2 = "Hobby2";
+            var hobbies = new List<Hobby>
+            {
+                new(name1),
+                new(name2)
+            };
+
+            _mockUnitOfWork.Setup(uow => uow.HobbyRepository.GetAllAsync())
+                .ReturnsAsync(hobbies);
+
+            // When
+            var result = await _hobbyService.GetHobbiesAsync();
+
+            // Then
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual(hobbies.First(), result.First());
+            Assert.AreEqual(hobbies.Last(), result.Last());
+            _mockUnitOfWork.Verify(uow => uow.HobbyRepository.GetAllAsync(), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task GetHobbiesAsync_ShouldReturnEmptyList()
+        {
+            // Given
+            _mockUnitOfWork.Setup(uow => uow.HobbyRepository.GetAllAsync())
+                .ReturnsAsync([]);
+
+            // When
+            var result = await _hobbyService.GetHobbiesAsync();
+
+            // Then
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Count());
+            _mockUnitOfWork.Verify(uow => uow.HobbyRepository.GetAllAsync(), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task GetHobbyById_ShouldReturnHobby()
+        {
+            // Given
+            var hobby = new Hobby("Hobby1");
+            Utils.SetupHobbyGuid(hobby, id);
+
+            _mockUnitOfWork.Setup(uow => uow.HobbyRepository.GetByIdAsync(id))
+                .ReturnsAsync(hobby);
+
+
+            // When
+            var result = await _hobbyService.GetHobbyByIdAsync(id);
+
+            // Then
+            Assert.IsNotNull(result);
+            Assert.AreEqual(hobby, result);
+            _mockUnitOfWork.Verify(uow => uow.HobbyRepository.GetByIdAsync(id), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task GetHobbyById_ShouldReturnNull()
+        {
+            // Given
+            _mockUnitOfWork.Setup(uow => uow.HobbyRepository.GetByIdAsync(id))
+                .ReturnsAsync((Hobby?)null);
+
+            // When
+            var result = await _hobbyService.GetHobbyByIdAsync(id);
+
+            // Then
+            Assert.IsNull(result);
+            _mockUnitOfWork.Verify(uow => uow.HobbyRepository.GetByIdAsync(id), Times.Once);
+        }
+    }
+}

--- a/ActiLink/ActiLink/Hobbies/HobbiesController.cs
+++ b/ActiLink/ActiLink/Hobbies/HobbiesController.cs
@@ -50,6 +50,9 @@ namespace ActiLink.Hobbies
         /// with the <see cref="HobbyDto"/> object or an error response if the hobby was not found.
         /// </returns>
         [HttpGet("{id}")]
+        [Authorize]
+        [ProducesResponseType<HobbyDto>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> GetHobbyByIdAsync(Guid id)
         {
             var hobby = await _hobbyService.GetHobbyByIdAsync(id);

--- a/ActiLink/ActiLink/Hobbies/HobbiesController.cs
+++ b/ActiLink/ActiLink/Hobbies/HobbiesController.cs
@@ -1,0 +1,57 @@
+﻿using ActiLink.Hobbies.DTOs;
+using ActiLink.Hobbies.Service;
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ActiLink.Hobbies
+{
+    /// <summary>
+    /// Controller for managing hobbies.        
+    /// </summary>
+    [Route("[controller]")]
+    [ApiController]
+    public class HobbiesController : ControllerBase
+    {
+        private readonly IHobbyService _hobbyService;
+        private readonly IMapper _mapper;
+        public HobbiesController(IHobbyService hobbyService, IMapper mapper)
+        {
+            _hobbyService = hobbyService ?? throw new ArgumentNullException(nameof(hobbyService));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        /// <summary>
+        /// Fetches a list of all hobbies.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IActionResult"/> 
+        /// with an <see cref="IEnumerable{T}"/> of <see cref="HobbyDto"/> objects.
+        /// </returns>
+        [HttpGet]
+        [Authorize]
+        [ProducesResponseType<IEnumerable<HobbyDto>>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> GetHobbiesAsync()
+        {
+            var hobbies = await _hobbyService.GetHobbiesAsync();
+            return Ok(_mapper.Map<IEnumerable<HobbyDto>>(hobbies));
+        }
+
+        /// <summary>
+        /// Fetches the hobby with specified ID.
+        /// </summary>
+        /// <param name="id">The hobby ID to fetch.</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IActionResult"/>
+        /// with the <see cref="HobbyDto"/> object or an error response if the hobby was not found.
+        /// </returns>
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetHobbyByIdAsync(Guid id)
+        {
+            var hobby = await _hobbyService.GetHobbyByIdAsync(id);
+            return hobby is null ? NotFound() : Ok(_mapper.Map<HobbyDto>(hobby));
+        }
+    }
+}

--- a/ActiLink/ActiLink/Hobbies/HobbiesController.cs
+++ b/ActiLink/ActiLink/Hobbies/HobbiesController.cs
@@ -14,10 +14,12 @@ namespace ActiLink.Hobbies
     [ApiController]
     public class HobbiesController : ControllerBase
     {
+        private readonly ILogger<HobbiesController> _logger;
         private readonly IHobbyService _hobbyService;
         private readonly IMapper _mapper;
-        public HobbiesController(IHobbyService hobbyService, IMapper mapper)
+        public HobbiesController(ILogger<HobbiesController> logger, IHobbyService hobbyService, IMapper mapper)
         {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _hobbyService = hobbyService ?? throw new ArgumentNullException(nameof(hobbyService));
             _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         }

--- a/ActiLink/ActiLink/Hobbies/Service/HobbyService.cs
+++ b/ActiLink/ActiLink/Hobbies/Service/HobbyService.cs
@@ -1,0 +1,24 @@
+﻿using ActiLink.Shared.Repositories;
+
+namespace ActiLink.Hobbies.Service
+{
+    public class HobbyService : IHobbyService
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        public HobbyService(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        }
+
+        public async Task<IEnumerable<Hobby>> GetHobbiesAsync()
+        {
+            return await _unitOfWork.HobbyRepository.GetAllAsync();
+        }
+
+        public async Task<Hobby?> GetHobbyByIdAsync(Guid id)
+        {
+            return await _unitOfWork.HobbyRepository.GetByIdAsync(id);
+        }
+
+    }
+}

--- a/ActiLink/ActiLink/Hobbies/Service/IHobbyService.cs
+++ b/ActiLink/ActiLink/Hobbies/Service/IHobbyService.cs
@@ -1,0 +1,8 @@
+﻿namespace ActiLink.Hobbies.Service
+{
+    public interface IHobbyService
+    {
+        public Task<IEnumerable<Hobby>> GetHobbiesAsync();
+        public Task<Hobby?> GetHobbyByIdAsync(Guid id);
+    }
+}

--- a/ActiLink/ActiLink/Program.cs
+++ b/ActiLink/ActiLink/Program.cs
@@ -2,6 +2,7 @@ using System.Text;
 using ActiLink;
 using ActiLink.Configuration;
 using ActiLink.Events.Service;
+using ActiLink.Hobbies.Service;
 using ActiLink.Organizers;
 using ActiLink.Organizers.Authentication;
 using ActiLink.Organizers.Users.Service;
@@ -49,6 +50,7 @@ builder.Services.Configure<JwtSettings>(builder.Configuration.GetSection("JwtSet
 // Add services
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IEventService, EventService>();
+builder.Services.AddScoped<IHobbyService, HobbyService>();
 builder.Services.AddScoped<JwtTokenProvider>();
 
 


### PR DESCRIPTION
This pull request introduces a new feature for managing hobbies, including the implementation of a controller, service, and unit tests. The changes are focused on creating a structured API for fetching hobbies and their details, along with thorough testing to ensure reliability.

### Controller Implementation:
* Added `HobbiesController` to handle HTTP requests for fetching all hobbies and fetching a hobby by ID. The controller uses dependency injection for `IHobbyService` and `IMapper` and includes proper response handling for success and error scenarios. (`ActiLink/ActiLink/Hobbies/HobbiesController.cs`, [ActiLink/ActiLink/Hobbies/HobbiesController.csR1-R59](diffhunk://#diff-061c0176226db41163344c04b070cd1df5b8bb10443d7af89cd47cc96b787f30R1-R59))

### Service Layer:
* Implemented `HobbyService` to interact with the data repository via `IUnitOfWork`. The service includes methods to fetch all hobbies and fetch a specific hobby by ID. (`ActiLink/ActiLink/Hobbies/Service/HobbyService.cs`, [ActiLink/ActiLink/Hobbies/Service/HobbyService.csR1-R24](diffhunk://#diff-6ddf412add9cf5b73bfd6b8a852902da2b4d6777cfd3acb922f61eb2b0d48373R1-R24))
* Defined `IHobbyService` interface to abstract the service layer and ensure testability. (`ActiLink/ActiLink/Hobbies/Service/IHobbyService.cs`, [ActiLink/ActiLink/Hobbies/Service/IHobbyService.csR1-R8](diffhunk://#diff-9c966d847f13f2699671d0d54380827c929ec38f1a4ef39e07269ddc083c50f2R1-R8))

### Unit Tests:
* Added unit tests for `HobbiesController` to validate the behavior of fetching all hobbies, fetching a specific hobby, and handling empty or not-found scenarios. (`ActiLink/ActiLink.UnitTests/HobbyTests/HobbiesControllerTests.cs`, [ActiLink/ActiLink.UnitTests/HobbyTests/HobbiesControllerTests.csR1-R145](diffhunk://#diff-be065dd22e83916f83c3ee973b142840dcd23b1b071eb75229fc6b37e689d2aaR1-R145))
* Added unit tests for `HobbyService` to verify its interaction with the repository and ensure correct data handling for all scenarios. (`ActiLink/ActiLink.UnitTests/HobbyTests/HobbyServiceTests.cs`, [ActiLink/ActiLink.UnitTests/HobbyTests/HobbyServiceTests.csR1-R108](diffhunk://#diff-4444241dedddfaa3bcef1ea81a4662a96c3c993a58beedef3128da35accebd1dR1-R108))