### PR TITLE
Fix/organizing events by business clients

### DIFF
--- a/ActiLink/ActiLink.UnitTests/EventTests/EventServiceTests.cs
+++ b/ActiLink/ActiLink.UnitTests/EventTests/EventServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using ActiLink.Events;
 using ActiLink.Events.Service;
 using ActiLink.Hobbies;
+using ActiLink.Organizers.BusinessClients;
 using ActiLink.Organizers.Users;
 using ActiLink.Shared.Model;
 using ActiLink.Shared.Repositories;
@@ -31,7 +32,7 @@ namespace ActiLink.UnitTests.EventTests
         }
 
         [TestMethod]
-        public async Task CreateEventAsync_Success_ReturnsSuccessResult()
+        public async Task CreateEventByUserAsync_Success_ReturnsSuccessResult()
         {
             // Given
             var userId = "TestUserId";
@@ -64,7 +65,7 @@ namespace ActiLink.UnitTests.EventTests
 
             // Setup repository add and save.
             _unitOfWorkMock
-                .Setup(u => u.UserRepository.GetByIdAsync(userId))
+                .Setup(u => u.OrganizerRepository.GetByIdAsync(userId))
                 .ReturnsAsync(organizer);
             _unitOfWorkMock
                 .Setup(u => u.EventRepository.AddAsync(It.IsAny<Event>()))
@@ -204,7 +205,7 @@ namespace ActiLink.UnitTests.EventTests
         }
 
         [TestMethod]
-        public async Task UpdateEventAsync_Success_ReturnsSuccessResult()
+        public async Task UpdateEventByUserAsync_Success_ReturnsSuccessResult()
         {
             // Given
             var userId = "TestUserId";
@@ -232,7 +233,7 @@ namespace ActiLink.UnitTests.EventTests
 
             _unitOfWorkMock.Setup(u => u.EventRepository).Returns(_mockEventRepository.Object);
             _unitOfWorkMock
-                .Setup(u => u.UserRepository.GetByIdAsync(userId))
+                .Setup(u => u.OrganizerRepository.GetByIdAsync(userId))
                 .ReturnsAsync(organizer);
 
             _mockHobbyRepository
@@ -298,7 +299,7 @@ namespace ActiLink.UnitTests.EventTests
         }
 
         [TestMethod]
-        public async Task DeleteEventByIdAsync_Success_ReturnsSuccessResult()
+        public async Task DeleteEventByIdByUserAsync_Success_ReturnsSuccessResult()
         {
             // Given
             var userId = "TestUserId";
@@ -348,6 +349,155 @@ namespace ActiLink.UnitTests.EventTests
             _unitOfWorkMock.Verify(u => u.EventRepository.Delete(It.IsAny<Event>()), Times.Never);
             _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Never);
         }
+
+
+        [TestMethod]
+        public async Task CreateEventByBusinessClient_Success_ReturnsSuccessResult()
+        {
+            // Given
+            var userId = "TestUserId";
+            var eventTitle = "Test Event";
+            var eventDescription = "This is a test event.";
+            var startTime = new DateTime(2024, 1, 1);
+            var endTime = startTime.AddHours(2);
+            var location = new Location(0, 0);
+            var price = 50m;
+            var minUsers = 1;
+            var maxUsers = 100;
+            var hobbyIds = new List<Guid>();
+            var hobby1 = new Hobby("Tenis");
+            var hobby2 = new Hobby("Piłka nożna");
+            var hobbies = new List<Hobby> { hobby1, hobby2 };
+
+            var createEventObject = new CreateEventObject(userId, eventTitle, eventDescription, startTime, endTime, location, price, minUsers, maxUsers, hobbyIds);
+            var organizer = new BusinessClient("TestUser", "test@example.com", "PL123456789") { Id = userId };
+            var createdEvent = new Event(organizer, eventTitle, eventDescription, startTime, endTime, location, price, minUsers, maxUsers, []);
+
+            _mockHobbyRepository
+                 .Setup(r => r.Query())
+                 .Returns(new TestAsyncEnumerable<Hobby>(hobbies));
+            _unitOfWorkMock.Setup(u => u.HobbyRepository).Returns(_mockHobbyRepository.Object);
+
+            // Setup mapper to map from CreateEventObject to Event.
+            _mapperMock
+                .Setup(m => m.Map<Event>(It.IsAny<CreateEventObject>(), It.IsAny<Action<IMappingOperationOptions<object, Event>>>()))
+                .Returns(createdEvent);
+
+            // Setup repository add and save.
+            _unitOfWorkMock
+                .Setup(u => u.OrganizerRepository.GetByIdAsync(userId))
+                .ReturnsAsync(organizer);
+            _unitOfWorkMock
+                .Setup(u => u.EventRepository.AddAsync(It.IsAny<Event>()))
+                .Returns(Task.CompletedTask);
+            _unitOfWorkMock
+                .Setup(u => u.SaveChangesAsync())
+                .ReturnsAsync(1);
+
+            // When
+            var result = await _eventService.CreateEventAsync(createEventObject);
+
+            // Then
+            Assert.IsTrue(result.Succeeded);
+            Assert.IsNotNull(result.Data);
+            Assert.AreEqual(createdEvent, result.Data);
+            _unitOfWorkMock.Verify(u => u.EventRepository.AddAsync(It.IsAny<Event>()), Times.Once);
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Once);
+            _unitOfWorkMock.Verify(u => u.OrganizerRepository.GetByIdAsync(userId), Times.Once);
+            _mapperMock.Verify(m => m.Map<Event>(It.IsAny<CreateEventObject>(), It.IsAny<Action<IMappingOperationOptions<object, Event>>>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task UpdateEventByBusinessClientAsync_Success_ReturnsSuccessResult()
+        {
+            // Given
+            var userId = "TestUserId";
+            var eventId = new Guid("030B4A82-1B7C-11CF-9D53-00AA003C9CB6");
+            var eventTitle = "Updated Event";
+            var eventDescription = "This is an updated event.";
+            var startTime = new DateTime(2024, 3, 1);
+            var endTime = startTime.AddHours(2);
+            var location = new Location(1, 1);
+            var price = 75m;
+            var minUsers = 2;
+            var maxUsers = 50;
+            var hobbyIds = new List<Guid>();
+
+            var updateEventObject = new UpdateEventObject(eventId, eventTitle, eventDescription, startTime, endTime,
+                                                        location, price, minUsers, maxUsers, hobbyIds);
+            var organizer = new BusinessClient("TestUser", "test@example.com", "PL123456789") { Id = userId };
+            var existingEvent = new Event(organizer, "Old Title", "Old Description", new DateTime(2024, 2, 6), new DateTime(2024, 2, 6).AddHours(3),
+                                         new Location(0, 0), 50.0m, 1, 10, []);
+            Utils.SetupEventGuid(existingEvent, eventId);
+
+            _mockEventRepository
+                .Setup(r => r.Query())
+                .Returns(new TestAsyncEnumerable<Event>([existingEvent]));
+
+            _unitOfWorkMock.Setup(u => u.EventRepository).Returns(_mockEventRepository.Object);
+            _unitOfWorkMock
+                .Setup(u => u.OrganizerRepository.GetByIdAsync(userId))
+                .ReturnsAsync(organizer);
+
+            _mockHobbyRepository
+                .Setup(r => r.Query())
+                .Returns(new TestAsyncEnumerable<Hobby>([]));
+            _unitOfWorkMock.Setup(u => u.HobbyRepository).Returns(_mockHobbyRepository.Object);
+
+            _unitOfWorkMock
+                .Setup(u => u.SaveChangesAsync())
+                .ReturnsAsync(1);
+
+
+            _mapperMock
+                 .Setup(m => m.Map<UpdateEventObject, Event>(It.IsAny<UpdateEventObject>(), It.IsAny<Event>(), It.IsAny<Action<IMappingOperationOptions<UpdateEventObject, Event>>>()))
+                 .Callback<UpdateEventObject, Event, Action<IMappingOperationOptions<UpdateEventObject, Event>>>((src, dest, opt) =>
+                 {
+                     typeof(Event).GetProperty(nameof(Event.Title))!.SetValue(dest, src.Title);
+                     typeof(Event).GetProperty(nameof(Event.Description))!.SetValue(dest, src.Description);
+                     typeof(Event).GetProperty(nameof(Event.StartTime))!.SetValue(dest, src.StartTime);
+                     typeof(Event).GetProperty(nameof(Event.EndTime))!.SetValue(dest, src.EndTime);
+                     typeof(Event).GetProperty(nameof(Event.Location))!.SetValue(dest, src.Location);
+                     typeof(Event).GetProperty(nameof(Event.Price))!.SetValue(dest, src.Price);
+                     typeof(Event).GetProperty(nameof(Event.MinUsers))!.SetValue(dest, src.MinUsers);
+                     typeof(Event).GetProperty(nameof(Event.MaxUsers))!.SetValue(dest, src.MaxUsers);
+                 });
+
+
+            // When
+            var result = await _eventService.UpdateEventAsync(updateEventObject, userId);
+
+            // Then
+            Assert.IsTrue(result.Succeeded);
+            Assert.IsNotNull(result.Data);
+            Assert.AreEqual(eventTitle, result.Data.Title);
+            Assert.AreEqual(eventDescription, result.Data.Description);
+            Assert.AreEqual(startTime, result.Data.StartTime);
+            Assert.AreEqual(endTime, result.Data.EndTime);
+            _unitOfWorkMock.Verify(u => u.EventRepository.Update(It.IsAny<Event>()), Times.Once);
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task UpdateEventByBusinessClientAsync_EventDoesNotExist_ReturnsFailureResult()
+        {
+            // Given
+            var userId = "TestUserId";
+            var eventId = new Guid("44494479-076b-47e1-8004-399a5aa58156");
+            var updateEventObject = new UpdateEventObject(eventId, "Updated Title", "Updated Description", DateTime.Now, DateTime.Now.AddHours(1),
+                                                          new Location(0, 0), 50.0m, 1, 10, []);
+            _mockEventRepository
+                .Setup(r => r.Query())
+                .Returns(new TestAsyncEnumerable<Event>([]));
+            _unitOfWorkMock.Setup(u => u.EventRepository).Returns(_mockEventRepository.Object);
+            // When
+            var result = await _eventService.UpdateEventAsync(updateEventObject, userId);
+            // Then
+            Assert.IsFalse(result.Succeeded);
+            Assert.IsTrue(result.Errors.Contains("Event not found"));
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Never);
+        }
+
     }
 
 

--- a/ActiLink/ActiLink/Events/Service/EventService.cs
+++ b/ActiLink/ActiLink/Events/Service/EventService.cs
@@ -30,7 +30,7 @@ namespace ActiLink.Events.Service
         public async Task<GenericServiceResult<Event>> CreateEventAsync(CreateEventObject ceo)
         {
             // Check if organizer exists
-            var organizer = await _unitOfWork.UserRepository.GetByIdAsync(ceo.OrganizerId);
+            var organizer = await _unitOfWork.OrganizerRepository.GetByIdAsync(ceo.OrganizerId);
             if (organizer is null)
                 return GenericServiceResult<Event>.Failure(["Organizer not found"]);
 

--- a/ActiLink/ActiLink/Shared/Repositories/IUnitOfWork.cs
+++ b/ActiLink/ActiLink/Shared/Repositories/IUnitOfWork.cs
@@ -1,5 +1,6 @@
 ﻿using ActiLink.Events;
 using ActiLink.Hobbies;
+using ActiLink.Organizers;
 using ActiLink.Organizers.Authentication;
 using ActiLink.Organizers.BusinessClients;
 using ActiLink.Organizers.Users;
@@ -16,6 +17,7 @@ namespace ActiLink.Shared.Repositories
         /// </summary>
         IRepository<User> UserRepository { get; }
         IRepository<BusinessClient> BusinessClientRepository { get; }
+        IRepository<Organizer> OrganizerRepository { get; }
         IRepository<Event> EventRepository { get; }
         IRepository<Hobby> HobbyRepository { get; }
         IRepository<RefreshToken> RefreshTokenRepository { get; }

--- a/ActiLink/ActiLink/Shared/Repositories/UnitOfWork.cs
+++ b/ActiLink/ActiLink/Shared/Repositories/UnitOfWork.cs
@@ -1,5 +1,6 @@
 ﻿using ActiLink.Events;
 using ActiLink.Hobbies;
+using ActiLink.Organizers;
 using ActiLink.Organizers.Authentication;
 using ActiLink.Organizers.BusinessClients;
 using ActiLink.Organizers.Users;
@@ -11,6 +12,7 @@ namespace ActiLink.Shared.Repositories
         private readonly ApiContext _context;
         private IRepository<User>? _userRepository;
         private IRepository<BusinessClient>? _businessClientRepository;
+        private IRepository<Organizer>? _organizerRepository;
         private IRepository<Event>? _eventRepository;
         private IRepository<Hobby>? _hobbyRepository;
         private IRepository<RefreshToken>? _refreshTokenRepository;
@@ -22,6 +24,7 @@ namespace ActiLink.Shared.Repositories
 
         public IRepository<User> UserRepository => _userRepository ??= new Repository<User>(_context);
         public IRepository<BusinessClient> BusinessClientRepository => _businessClientRepository ??= new Repository<BusinessClient>(_context);
+        public IRepository<Organizer> OrganizerRepository => _organizerRepository ??= new Repository<Organizer>(_context);
         public IRepository<Event> EventRepository => _eventRepository ??= new Repository<Event>(_context);
         public IRepository<Hobby> HobbyRepository => _hobbyRepository ??= new Repository<Hobby>(_context);
         public IRepository<RefreshToken> RefreshTokenRepository => _refreshTokenRepository ??= new Repository<RefreshToken>(_context);


### PR DESCRIPTION
This pull request introduces changes to enhance event management functionality by adding support for `Organizer` entities and extending test coverage. The most significant updates include refactoring to use the `OrganizerRepository`, adding new test cases for business clients, and updating method names for clarity.

### Refactoring for Organizer Support:
* Replaced usage of `UserRepository` with `OrganizerRepository` in `EventService` to handle organizer-specific logic. (`ActiLink/ActiLink/Events/Service/EventService.cs`, [ActiLink/ActiLink/Events/Service/EventService.csL33-R33](diffhunk://#diff-da5ce15730a34866d57fff05a3009fdb6f6899d3b29a933c2575a3cc42f2e416L33-R33))
* Added `OrganizerRepository` to `IUnitOfWork` and its implementation in `UnitOfWork`. (`ActiLink/ActiLink/Shared/Repositories/IUnitOfWork.cs`, [[1]](diffhunk://#diff-9e05e128e78809ef7b632a3135f0a9cca0b305d3b75c5597995f256b4e199185R20); `ActiLink/ActiLink/Shared/Repositories/UnitOfWork.cs`, [[2]](diffhunk://#diff-cbaa27f3b59e1bfedbe437696da567b734da89b6513614e27fbd19cde8597c53R15) [[3]](diffhunk://#diff-cbaa27f3b59e1bfedbe437696da567b734da89b6513614e27fbd19cde8597c53R27)

### Test Enhancements:
* Added new test cases for creating and updating events by business clients, including both success and failure scenarios. (`ActiLink/ActiLink.UnitTests/EventTests/EventServiceTests.cs`, [[1]](diffhunk://#diff-027db81b5225d7fee489510a9753c4f182fb07639fa2b5df9290d6b246a89318R352-R500); `ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs`, [[2]](diffhunk://#diff-68defbdd80292c150e886b0d24ca07b4f017f0aa12f97ac0576a7be540daf3d5R587-R698)
* Updated existing test cases to use `OrganizerRepository` instead of `UserRepository` for organizer-related operations. (`ActiLink/ActiLink.UnitTests/EventTests/EventServiceTests.cs`, [[1]](diffhunk://#diff-027db81b5225d7fee489510a9753c4f182fb07639fa2b5df9290d6b246a89318L67-R68) [[2]](diffhunk://#diff-027db81b5225d7fee489510a9753c4f182fb07639fa2b5df9290d6b246a89318L235-R236)

### Naming Updates for Clarity:
* Renamed test methods to reflect whether they involve users or business clients, improving readability. (`ActiLink/ActiLink.UnitTests/EventTests/EventServiceTests.cs`, [[1]](diffhunk://#diff-027db81b5225d7fee489510a9753c4f182fb07639fa2b5df9290d6b246a89318L34-R35) [[2]](diffhunk://#diff-027db81b5225d7fee489510a9753c4f182fb07639fa2b5df9290d6b246a89318L207-R208); `ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs`, [[3]](diffhunk://#diff-68defbdd80292c150e886b0d24ca07b4f017f0aa12f97ac0576a7be540daf3d5L43-R44) [[4]](diffhunk://#diff-68defbdd80292c150e886b0d24ca07b4f017f0aa12f97ac0576a7be540daf3d5L100-R101)