### PR TITLE
Fix updating user hobbies

### DIFF
--- a/ActiLink/ActiLink/Organizers/Users/Service/UserService.cs
+++ b/ActiLink/ActiLink/Organizers/Users/Service/UserService.cs
@@ -145,7 +145,7 @@ namespace ActiLink.Organizers.Users.Service
         /// </returns>
         public async Task<GenericServiceResult<User>> UpdateUserAsync(string id, UpdateUserObject updateUserObject)
         {
-            var user = await GetUserByIdAsync(id);
+            var user = await GetUserWithHobbiesByIdAsync(id);
             if (user is null)
                 return GenericServiceResult<User>.Failure(UserNotFoundError, ErrorCode.NotFound);
 
@@ -163,7 +163,8 @@ namespace ActiLink.Organizers.Users.Service
                 return GenericServiceResult<User>.Failure(result.Errors.Select(e => e.Description), ErrorCode.ValidationError);
 
 
-            user.Hobbies = hobbies;
+            user.Hobbies.Clear();
+            hobbies.ForEach(user.Hobbies.Add);
             result = await _userManager.UpdateAsync(user);
 
             return result.Succeeded ? GenericServiceResult<User>.Success(user) : GenericServiceResult<User>.Failure(result.Errors.Select(e => e.Description));


### PR DESCRIPTION
This pull request updates the `UpdateUserAsync` method in `UserService.cs` to ensure proper handling of user hobbies during updates. The changes improve data consistency and prevent potential issues with duplicate or stale hobby entries.

### Changes to hobby handling in `UpdateUserAsync`:

* Replaced the call to `GetUserByIdAsync` with `GetUserWithHobbiesByIdAsync` to include hobbies in the retrieved user object.
* Updated the logic for modifying user hobbies: instead of overwriting the `Hobbies` collection, the method now clears the existing hobbies and adds the new ones individually. This ensures a clean and consistent update.