### PR TITLE
Feature/event enroll

### DIFF
--- a/ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs
+++ b/ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs
@@ -744,7 +744,7 @@ namespace ActiLink.UnitTests.EventTests
 
 
             // When
-            var actionResult = await _controller.EnrollEventAsync(eventId);
+            var actionResult = await _controller.SignUpForEventAsync(eventId);
 
 
             // Then
@@ -774,7 +774,7 @@ namespace ActiLink.UnitTests.EventTests
             _controller.ControllerContext.HttpContext.User = principal;
 
             // When
-            var actionResult = await _controller.EnrollEventAsync(eventId);
+            var actionResult = await _controller.SignUpForEventAsync(eventId);
 
             // Then
             Assert.IsInstanceOfType<ForbidResult>(actionResult);

--- a/ActiLink/ActiLink/Events/EventsController.cs
+++ b/ActiLink/ActiLink/Events/EventsController.cs
@@ -220,5 +220,63 @@ namespace ActiLink.Events
                 return StatusCode(StatusCodes.Status500InternalServerError, "An unexpected error occurred");
             }
         }
+
+        /// <summary>
+        /// Enrolls the user in the event with the specified ID.
+        /// </summary>
+        /// <param name="id">The ID of the event to enroll in.</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IActionResult"/> of the operation
+        /// with the <see cref="EventDto"/> object or an error response.
+        /// </returns>
+        [HttpPost("{id}/enroll")]
+        [Authorize(Roles = "User")] // Nie działa z claimsasmi, trzeba by użyć user managera do dodawania roli
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> EnrollEventAsync(Guid id)
+        {
+            try
+            {
+                var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (userId is null)
+                {
+                    _logger.LogWarning("User ID not found in token");
+                    return Unauthorized("User ID not found in token");
+                }
+
+                var userRole = User.FindFirst(ClaimTypes.Role)?.Value;
+                if (userRole is null)
+                {
+                    _logger.LogWarning("User role not found in token");
+                    return Unauthorized("User role not found in token");
+                }
+
+                if (userRole != "User")
+                {
+                    _logger.LogWarning("User is not authorized to enroll in events");
+                    return Forbid("User is not authorized to enroll in events");
+                }
+
+                var result = await _eventService.SignUpForEventAsync(id, userId);
+                if (!result.Succeeded)
+                {
+                    return result.ErrorCode switch
+                    {
+                        ErrorCode.Forbidden => Forbid(),
+                        ErrorCode.NotFound => NotFound(),
+                        _ => BadRequest(result.Errors),
+                    };
+                }
+
+                return Ok(_mapper.Map<EventDto>(result.Data!));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An unexpected error occurred while enrolling for the event {id}", id);
+            }
+            return StatusCode(StatusCodes.Status500InternalServerError, "An unexpected error occurred");
+        }
     }
 }

--- a/ActiLink/ActiLink/Events/EventsController.cs
+++ b/ActiLink/ActiLink/Events/EventsController.cs
@@ -235,7 +235,7 @@ namespace ActiLink.Events
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> EnrollEventAsync(Guid id)
+        public async Task<IActionResult> SignUpForEventAsync(Guid id)
         {
             try
             {

--- a/ActiLink/ActiLink/Events/Infrastructure/EventRepositoryExtensions.cs
+++ b/ActiLink/ActiLink/Events/Infrastructure/EventRepositoryExtensions.cs
@@ -14,6 +14,7 @@ namespace ActiLink.Events.Infrastructure
                 .Include(e => e.RelatedHobbies)
                 .FirstOrDefaultAsync(e => e.Id == id);
         }
+
         public static async Task<IEnumerable<Event>> GetAllEventsAsync(this IRepository<Event> repository)
         {
             return await repository

--- a/ActiLink/ActiLink/Events/Service/IEventService.cs
+++ b/ActiLink/ActiLink/Events/Service/IEventService.cs
@@ -10,5 +10,6 @@ namespace ActiLink.Events.Service
         public Task<IEnumerable<Event>> GetAllEventsAsync();
         public Task<GenericServiceResult<Event>> UpdateEventAsync(Guid eventId, UpdateEventObject eventToUpdate, string userIdFromToken);
         public Task<ServiceResult> DeleteEventByIdAsync(Guid eventId, string userIdFromToken);
+        public Task<GenericServiceResult<Event>> SignUpForEventAsync(Guid eventId, string userIdFromToken);
     }
 }

--- a/ActiLink/ActiLink/Organizers/Users/Infrastructure/UserRepositoryExtensions.cs
+++ b/ActiLink/ActiLink/Organizers/Users/Infrastructure/UserRepositoryExtensions.cs
@@ -12,5 +12,12 @@ namespace ActiLink.Organizers.Users.Infrastructure
                 .Include(u => u.Hobbies)
                 .FirstOrDefaultAsync(u => u.Id == userId);
         }
+        public static async Task<User?> GetUserWithSignedUpEventsByIdAsync(this IRepository<User> repository, string userId)
+        {
+            return await repository
+                .Query()
+                .Include(u => u.SignedUpEvents)
+                .FirstOrDefaultAsync(u => u.Id == userId);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces functionality for users to enroll in events, including backend service logic, controller endpoints, and unit tests. The changes primarily focus on extending the `EventService`, `EventsController`, and associated repositories to support this feature.

### New Features and Enhancements:

#### Backend Service Logic:
* Added `SignUpForEventAsync` to `EventService` to handle user enrollment in events, including validations for event existence, user duplication, and capacity limits.
* Updated `IEventService` interface to include the new `SignUpForEventAsync` method.

#### Repository Extensions:
* Added `GetUserWithSignedUpEventsByIdAsync` to `UserRepositoryExtensions` for fetching users along with their signed-up events.

#### Controller Updates:
* Introduced a new `SignUpForEventAsync` endpoint in `EventsController` to allow users to enroll in events via HTTP POST. The endpoint includes role-based authorization and error handling for various scenarios.

#### Unit Tests:
* Added comprehensive unit tests in `EventServiceTests` to cover scenarios such as successful enrollment, event not found, user already signed up, and event capacity limits.
* Added controller-level tests in `EventsControllerTests` to validate the new endpoint's behavior, including success and forbidden cases.

### Supporting Changes:
* Updated imports in multiple files (`EventServiceTests.cs`, `EventService.cs`) to include necessary dependencies for the new functionality. [[1]](diffhunk://#diff-027db81b5225d7fee489510a9753c4f182fb07639fa2b5df9290d6b246a89318R2-R5) [[2]](diffhunk://#diff-da5ce15730a34866d57fff05a3009fdb6f6899d3b29a933c2575a3cc42f2e416R3)