### PR TITLE
Feature/event withdraw

### DIFF
--- a/ActiLink/ActiLink.UnitTests/EventTests/EventServiceTests.cs
+++ b/ActiLink/ActiLink.UnitTests/EventTests/EventServiceTests.cs
@@ -715,7 +715,7 @@ namespace ActiLink.UnitTests.EventTests
                 .ReturnsAsync(1);
 
             // When
-            var result = await _eventService.UnsignFromEventAsync(eventId, userId);
+            var result = await _eventService.WithdrawFromEventAsync(eventId, userId);
 
             // Then
             Assert.IsTrue(result.Succeeded);
@@ -749,7 +749,7 @@ namespace ActiLink.UnitTests.EventTests
             _unitOfWorkMock.Setup(u => u.UserRepository).Returns(_mockUserRepository.Object);
 
             // When
-            var result = await _eventService.UnsignFromEventAsync(eventId, userId);
+            var result = await _eventService.WithdrawFromEventAsync(eventId, userId);
 
             // Then
             Assert.IsFalse(result.Succeeded);

--- a/ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs
+++ b/ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs
@@ -797,7 +797,7 @@ namespace ActiLink.UnitTests.EventTests
 
             // Mocking the service result
             _eventServiceMock
-                .Setup(es => es.UnsignFromEventAsync(eventId, userId))
+                .Setup(es => es.WithdrawFromEventAsync(eventId, userId))
                 .ReturnsAsync(GenericServiceResult<Event>.Success(eventToUnsign));
 
             _mapperMock
@@ -815,7 +815,7 @@ namespace ActiLink.UnitTests.EventTests
             _controller.ControllerContext.HttpContext.User = principal;
 
             // When
-            var actionResult = await _controller.UnsignFromEventAsync(eventId);
+            var actionResult = await _controller.WithdrawFromEventAsync(eventId);
 
             // Then
             var okObjectResult = actionResult as OkObjectResult;
@@ -844,7 +844,7 @@ namespace ActiLink.UnitTests.EventTests
             _controller.ControllerContext.HttpContext.User = principal;
 
             // When
-            var actionResult = await _controller.UnsignFromEventAsync(eventId);
+            var actionResult = await _controller.WithdrawFromEventAsync(eventId);
 
             // Then
             Assert.IsInstanceOfType<ForbidResult>(actionResult);

--- a/ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs
+++ b/ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs
@@ -7,6 +7,7 @@ using ActiLink.Organizers;
 using ActiLink.Organizers.BusinessClients;
 using ActiLink.Organizers.DTOs;
 using ActiLink.Organizers.Users;
+using ActiLink.Organizers.Users.DTOs;
 using ActiLink.Shared.Model;
 using ActiLink.Shared.ServiceUtils;
 using AutoMapper;
@@ -718,9 +719,11 @@ namespace ActiLink.UnitTests.EventTests
             var userId = "TestUserId";
             var eventId = new Guid("030B4A82-1B7C-11CF-9D53-00AA003C9CB6");
             var user = new User("Test User", "testuser@email.com") { Id = userId };
+            var userDto = new UserDto(user.Id, user.UserName!);
             var eventToSignUp = new Event(null!, "Test Event", "Description", DateTime.Now, DateTime.Now.AddHours(2), new Location(0, 0), 0m, 1, 10, []);
             Utils.SetupEventGuid(eventToSignUp, eventId);
-            var expectedEventDto = new EventDto(eventId, "Test Event", "Description", DateTime.Now, DateTime.Now.AddHours(2), new Location(0, 0), 0m, 1, 10, [], null!, []);
+            eventToSignUp.SignUpList.Add(user);
+            var expectedEventDto = new EventDto(eventId, "Test Event", "Description", DateTime.Now, DateTime.Now.AddHours(2), new Location(0, 0), 0m, 1, 10, [], null!, [userDto]);
 
             // Mocking the service result
             _eventServiceMock
@@ -775,6 +778,73 @@ namespace ActiLink.UnitTests.EventTests
 
             // When
             var actionResult = await _controller.SignUpForEventAsync(eventId);
+
+            // Then
+            Assert.IsInstanceOfType<ForbidResult>(actionResult);
+        }
+
+        [TestMethod]
+        public async Task WithdrawEventByUser_Success_ReturnsOkResult()
+        {
+            // Given
+            var userId = "TestUserId";
+            var user = new User("Test User", "testuser@email.com") { Id = userId };
+            var eventId = new Guid("030B4A82-1B7C-11CF-9D53-00AA003C9CB6");
+            var eventToUnsign = new Event(null!, "Test Event", "Description", DateTime.Now, DateTime.Now.AddHours(2), new Location(0, 0), 0m, 1, 10, []);
+            Utils.SetupEventGuid(eventToUnsign, eventId);
+            eventToUnsign.SignUpList.Add(user);
+            var expectedEventDto = new EventDto(eventId, "Test Event", "Description", DateTime.Now, DateTime.Now.AddHours(2), new Location(0, 0), 0m, 1, 10, [], null!, []);
+
+            // Mocking the service result
+            _eventServiceMock
+                .Setup(es => es.UnsignFromEventAsync(eventId, userId))
+                .ReturnsAsync(GenericServiceResult<Event>.Success(eventToUnsign));
+
+            _mapperMock
+                .Setup(m => m.Map<EventDto>(eventToUnsign))
+                .Returns(expectedEventDto);
+
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, userId),
+                new(ClaimTypes.Role, "User")
+            };
+
+            var identity = new ClaimsIdentity(claims, "TestAuthType");
+            var principal = new ClaimsPrincipal(identity);
+            _controller.ControllerContext.HttpContext.User = principal;
+
+            // When
+            var actionResult = await _controller.UnsignFromEventAsync(eventId);
+
+            // Then
+            var okObjectResult = actionResult as OkObjectResult;
+            Assert.IsNotNull(okObjectResult);
+            Assert.AreEqual(StatusCodes.Status200OK, okObjectResult.StatusCode);
+            Assert.IsNotNull(okObjectResult.Value);
+            var enrolledEventDto = okObjectResult.Value as EventDto;
+            Assert.IsNotNull(enrolledEventDto);
+            Assert.AreEqual(expectedEventDto, enrolledEventDto);
+        }
+
+        [TestMethod]
+        public async Task WithdrawEventByBusinessClient_Forbidden_Returns()
+        {
+            // Given
+            var userId = "TestUserId";
+            var eventId = new Guid("030B4A82-1B7C-11CF-9D53-00AA003C9CB6");
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, userId),
+                new(ClaimTypes.Role, "BusinessClient")
+            };
+
+            var identity = new ClaimsIdentity(claims, "TestAuthType");
+            var principal = new ClaimsPrincipal(identity);
+            _controller.ControllerContext.HttpContext.User = principal;
+
+            // When
+            var actionResult = await _controller.UnsignFromEventAsync(eventId);
 
             // Then
             Assert.IsInstanceOfType<ForbidResult>(actionResult);

--- a/ActiLink/ActiLink/Events/EventsController.cs
+++ b/ActiLink/ActiLink/Events/EventsController.cs
@@ -293,7 +293,7 @@ namespace ActiLink.Events
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> UnsignFromEventAsync(Guid id)
+        public async Task<IActionResult> WithdrawFromEventAsync(Guid id)
         {
             try
             {
@@ -317,7 +317,7 @@ namespace ActiLink.Events
                     return Forbid("User is not authorized to enroll in events");
                 }
 
-                var result = await _eventService.UnsignFromEventAsync(id, userId);
+                var result = await _eventService.WithdrawFromEventAsync(id, userId);
                 if (!result.Succeeded)
                 {
                     return result.ErrorCode switch

--- a/ActiLink/ActiLink/Events/Service/EventService.cs
+++ b/ActiLink/ActiLink/Events/Service/EventService.cs
@@ -168,6 +168,12 @@ namespace ActiLink.Events.Service
             return await _unitOfWork.EventRepository.GetAllEventsAsync();
         }
 
+        /// <summary>
+        /// Signs up the user for the specified event.
+        /// </summary>
+        /// <param name="eventId"></param>
+        /// <param name="userIdFromToken"></param>
+        /// <returns></returns>
         public async Task<GenericServiceResult<Event>> SignUpForEventAsync(Guid eventId, string userIdFromToken)
         {
             var eventToSignUp = await _unitOfWork.EventRepository.GetByIdWithOrganizerAsync(eventId);
@@ -192,6 +198,36 @@ namespace ActiLink.Events.Service
             return result > 0
                 ? GenericServiceResult<Event>.Success(eventToSignUp)
                 : GenericServiceResult<Event>.Failure(["Failed to sign up for event"]);
+        }
+
+
+        /// <summary>
+        /// Unsigns the user from the specified event.
+        /// </summary>
+        /// <param name="eventId"></param>
+        /// <param name="userIdFromToken"></param>
+        /// <returns></returns>
+        public async Task<GenericServiceResult<Event>> UnsignFromEventAsync(Guid eventId, string userIdFromToken)
+        {
+            var eventToUnsign = await _unitOfWork.EventRepository.GetByIdWithOrganizerAsync(eventId);
+
+            if (eventToUnsign is null)
+                return GenericServiceResult<Event>.Failure(["Event not found"], ErrorCode.NotFound);
+
+            if(eventToUnsign.SignUpList.All(u => u.Id != userIdFromToken))
+                return GenericServiceResult<Event>.Failure(["You are not signed up for this event."], ErrorCode.ValidationError);
+
+            var user = await _unitOfWork.UserRepository.GetUserWithSignedUpEventsByIdAsync(userIdFromToken);
+            if (user is null)
+                return GenericServiceResult<Event>.Failure(["User not found"], ErrorCode.NotFound);
+
+            eventToUnsign.SignUpList.Remove(user);
+            user.SignedUpEvents.Remove(eventToUnsign);
+
+            var result = await _unitOfWork.SaveChangesAsync();
+            return result > 0
+                ? GenericServiceResult<Event>.Success(eventToUnsign)
+                : GenericServiceResult<Event>.Failure(["Failed to unsign from event"]);
         }
     }
 }

--- a/ActiLink/ActiLink/Events/Service/EventService.cs
+++ b/ActiLink/ActiLink/Events/Service/EventService.cs
@@ -207,7 +207,7 @@ namespace ActiLink.Events.Service
         /// <param name="eventId"></param>
         /// <param name="userIdFromToken"></param>
         /// <returns></returns>
-        public async Task<GenericServiceResult<Event>> UnsignFromEventAsync(Guid eventId, string userIdFromToken)
+        public async Task<GenericServiceResult<Event>> WithdrawFromEventAsync(Guid eventId, string userIdFromToken)
         {
             var eventToUnsign = await _unitOfWork.EventRepository.GetByIdWithOrganizerAsync(eventId);
 

--- a/ActiLink/ActiLink/Events/Service/IEventService.cs
+++ b/ActiLink/ActiLink/Events/Service/IEventService.cs
@@ -11,6 +11,6 @@ namespace ActiLink.Events.Service
         public Task<GenericServiceResult<Event>> UpdateEventAsync(Guid eventId, UpdateEventObject eventToUpdate, string userIdFromToken);
         public Task<ServiceResult> DeleteEventByIdAsync(Guid eventId, string userIdFromToken);
         public Task<GenericServiceResult<Event>> SignUpForEventAsync(Guid eventId, string userIdFromToken);
-        public Task<GenericServiceResult<Event>> UnsignFromEventAsync(Guid eventId, string userIdFromToken);
+        public Task<GenericServiceResult<Event>> WithdrawFromEventAsync(Guid eventId, string userIdFromToken);
     }
 }

--- a/ActiLink/ActiLink/Events/Service/IEventService.cs
+++ b/ActiLink/ActiLink/Events/Service/IEventService.cs
@@ -11,5 +11,6 @@ namespace ActiLink.Events.Service
         public Task<GenericServiceResult<Event>> UpdateEventAsync(Guid eventId, UpdateEventObject eventToUpdate, string userIdFromToken);
         public Task<ServiceResult> DeleteEventByIdAsync(Guid eventId, string userIdFromToken);
         public Task<GenericServiceResult<Event>> SignUpForEventAsync(Guid eventId, string userIdFromToken);
+        public Task<GenericServiceResult<Event>> UnsignFromEventAsync(Guid eventId, string userIdFromToken);
     }
 }


### PR DESCRIPTION
This pull request introduces functionality for users to withdraw from events, including updates to the service, controller, and unit tests. Key changes include adding the `UnsignFromEventAsync` method to the service layer, creating a corresponding API endpoint, and implementing test cases for the new functionality.

### New functionality for withdrawing from events:

* **Service Layer:**
  - Added `UnsignFromEventAsync` method to `EventService` to handle user withdrawal from events, including validation for non-existent events or users not signed up. (`ActiLink/ActiLink/Events/Service/EventService.cs`, [ActiLink/ActiLink/Events/Service/EventService.csR202-R231](diffhunk://#diff-da5ce15730a34866d57fff05a3009fdb6f6899d3b29a933c2575a3cc42f2e416R202-R231))
  - Updated `IEventService` interface to include the new `UnsignFromEventAsync` method. (`ActiLink/ActiLink/Events/Service/IEventService.cs`, [ActiLink/ActiLink/Events/Service/IEventService.csR14](diffhunk://#diff-4b6060a37073507b0722fbf51193056aa0e304e38b5689deba6d9aced6192631R14))

* **Controller Layer:**
  - Added `UnsignFromEventAsync` API endpoint in `EventsController` to allow users to withdraw from events, with appropriate error handling and role-based authorization. (`ActiLink/ActiLink/Events/EventsController.cs`, [ActiLink/ActiLink/Events/EventsController.csR278-R339](diffhunk://#diff-af11ed5b79fc2b778d13e18a550bd34381ff4d1cf3d9a08a3a1c95c5aeeab9ebR278-R339))

### Unit tests for withdrawal functionality:

* **Service Tests:**
  - Added test cases for `UnsignFromEventAsync` in `EventServiceTests` to verify successful withdrawal and validation errors when the user is not signed up for the event. (`ActiLink/ActiLink.UnitTests/EventTests/EventServiceTests.cs`, [ActiLink/ActiLink.UnitTests/EventTests/EventServiceTests.csR691-R760](diffhunk://#diff-027db81b5225d7fee489510a9753c4f182fb07639fa2b5df9290d6b246a89318R691-R760))

* **Controller Tests:**
  - Added test cases for `UnsignFromEventAsync` in `EventsControllerTests` to validate successful withdrawal, forbidden access for non-user roles, and proper response structure. (`ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs`, [ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.csR785-R851](diffhunk://#diff-68defbdd80292c150e886b0d24ca07b4f017f0aa12f97ac0576a7be540daf3d5R785-R851))

### Minor changes:

* Updated DTO usage in `EnrollEventByUser_Success_ReturnsOkResult` test to include user details in the event's signup list. (`ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs`, [ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.csR722-R726](diffhunk://#diff-68defbdd80292c150e886b0d24ca07b4f017f0aa12f97ac0576a7be540daf3d5R722-R726))
* Added missing `using` directive for `ActiLink.Organizers.Users.DTOs`. (`ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.cs`, [ActiLink/ActiLink.UnitTests/EventTests/EventsControllerTests.csR10](diffhunk://#diff-68defbdd80292c150e886b0d24ca07b4f017f0aa12f97ac0576a7be540daf3d5R10))